### PR TITLE
fix: show a note in about instead of reload snackbar

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -46,22 +46,6 @@
       </v-navigation-drawer>
     </template>
 
-    <v-snackbar
-      color="primary"
-      :timeout="-1"
-      :value="$store.state.isUpdateAvailable"
-    >
-      A new version was downloaded.
-      <template #action>
-        <v-btn
-          outlined
-          @click="reload"
-        >
-          Reload to activate.
-        </v-btn>
-      </template>
-    </v-snackbar>
-
     <v-main>
       <v-slide-y-transition mode="out-in">
         <router-view />

--- a/src/components/BuildInfo.vue
+++ b/src/components/BuildInfo.vue
@@ -12,6 +12,11 @@
         {{ buildCommitHash }}
       </a>
     </p>
+
+    <p v-if="$store.state.isUpdateAvailable">
+      A new version is available and will be automatically installed when you
+      close all open tabs.
+    </p>
   </section>
 </template>
 


### PR DESCRIPTION
Simple reload doesn't work and I don't think it's worth the time to implement it properly.