### PR TITLE
fix: the importscript function accepts arbitrary pyt... in index.js

### DIFF
--- a/src/importScript/index.js
+++ b/src/importScript/index.js
@@ -67,7 +67,17 @@ class IPs {
   }
 }
 
+// Guards against denial-of-service via extremely large or pathological inputs
+// being fed straight into the ANTLR lexer/parser.
+const maxImportScriptLength = 1_000_000;
+
 function parse(input) {
+  if (typeof input !== "string" || input.length > maxImportScriptLength) {
+    throw new Error(
+      `Import script exceeds the maximum allowed length of ${maxImportScriptLength} characters.`,
+    );
+  }
+
   const chars = new InputStream(input);
   const lexer = new Python2Lexer(chars);
   const tokens = new CommonTokenStream(lexer);


### PR DESCRIPTION
## Summary
Fix high severity security issue in `src/importScript/index.js`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `src/importScript/index.js:76` |
| **Assessment** | Likely exploitable |

**Description**: The importScript function accepts arbitrary Python code input and passes it directly to the ANTLR parser without validation, size limits, or timeout controls. An attacker can provide malicious Python files that could cause denial of service through algorithmic complexity attacks or parser crashes.

## Evidence

**Scanner confirmation**: multi_agent_ai rule `V-001` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This is a web application - XSS and injection vulnerabilities can affect end users.

## Changes
- `src/importScript/index.js`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
